### PR TITLE
Fix Fatal Exception: NSInternalInconsistencyException negative sizes …

### DIFF
--- a/QBImagePicker/QBAssetsViewController.m
+++ b/QBImagePicker/QBAssetsViewController.m
@@ -666,6 +666,12 @@ static CGSize CGSizeScale(CGSize size, CGFloat scale) {
     
     CGFloat width = (CGRectGetWidth(self.view.frame) - 2.0 * (numberOfColumns - 1)) / numberOfColumns;
     
+    // Fatal Exception: NSInternalInconsistencyException negative sizes are not supported in the flow layout
+    // The width and height of the specified item. Both values must be greater than 0.
+    if (width <= 0) {
+        width = 1.0f;
+    }
+    
     return CGSizeMake(width, width);
 }
 


### PR DESCRIPTION
…are not supported in the flow layout.

We have recently received a flurry of crash reports (for an app developed in NativeScript) that I believe are connected to this package. See the stack trace below:

![image](https://user-images.githubusercontent.com/70568004/124604301-17f91980-de6b-11eb-866d-fd6509293b04.png)

[A fix for this was applied to another fork of QBImagePicker.](https://github.com/smartmobilefactory/QBImagePicker/commit/13ce139351159dafecbde65a6127eb1e0628e805#diff-6867ab519767f28278432bf69b8c7a47807807610803bc1fd0568e390c02c5ec)

Would it be ok to include the same fix here?